### PR TITLE
Fixed problem for 64 bit machines. ptrace works with _long_, rather than _int_ .

### DIFF
--- a/part2/debuglib.c
+++ b/part2/debuglib.c
@@ -76,7 +76,7 @@ void dump_process_memory(pid_t pid, unsigned from_addr, unsigned to_addr)
 */
 struct debug_breakpoint_t {
     void* addr;
-    unsigned orig_data;
+    unsigned long orig_data;
 };
 
 
@@ -97,7 +97,7 @@ static void enable_breakpoint(pid_t pid, debug_breakpoint* bp)
 static void disable_breakpoint(pid_t pid, debug_breakpoint* bp)
 {
     assert(bp);
-    unsigned data = ptrace(PTRACE_PEEKTEXT, pid, bp->addr, 0);
+    unsigned long data = ptrace(PTRACE_PEEKTEXT, pid, bp->addr, 0);
     assert((data & 0xFF) == 0xCC);
     ptrace(PTRACE_POKETEXT, pid, bp->addr, (data & ~(0xFF)) | (bp->orig_data & 0xFF));
 }


### PR DESCRIPTION
This is an issue when switching from 32 to 64 bit Linux (_long_ is 32 and 64 bit long, respectively). If you pass an _int_ (32 bits) then ptrace fills the missing 32 bits in the input with 0s and thus overwrites the object code with 0s. Updated accordingly. Tested on my PC and works fine (uname -r: 3.16.0-4-amd64; gcc -v: 4.9.2). 

PS. _int_ stands for int in C, _long_ stands for long in C.
